### PR TITLE
Exposing a method on Enterprise for retrieving enterprise token metadata

### DIFF
--- a/packages/enterprise/src/enterprise.ts
+++ b/packages/enterprise/src/enterprise.ts
@@ -1,6 +1,6 @@
 import { AccountId, AssetId, AssetType, ChainId } from 'caip';
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
-import { Address, BlockchainProvider } from '@iqprotocol/abstract-blockchain';
+import { Address, BlockchainProvider, FungibleTokenMetadata } from '@iqprotocol/abstract-blockchain';
 import {
   Enterprise,
   EnterpriseConfigWriter,
@@ -117,6 +117,10 @@ export class EnterpriseImpl<Transaction = unknown>
 
   async getStakingReward(stakeTokenId: AssetId): Promise<BigNumber> {
     return this.blockchainEnterprise.getStakingReward(this.stakeAssetIdToTokenId(stakeTokenId));
+  }
+
+  async getEnterpriseTokenMetadata(): Promise<FungibleTokenMetadata> {
+    return this.blockchainEnterprise.getEnterpriseTokenMetadata();
   }
 
   async claimStakingReward(stakeTokenId: AssetId): Promise<Transaction> {

--- a/packages/enterprise/src/types.ts
+++ b/packages/enterprise/src/types.ts
@@ -3,6 +3,7 @@ import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import {
   AccountState as OnChainAccountState,
   EnterpriseInfo as OnChainEnterpriseInfo,
+  FungibleTokenMetadata,
   RentalAgreement as OnChainRentalAgreement,
   ServiceInfo as OnChainServiceInfo,
   Stake as OnChainStake,
@@ -153,6 +154,8 @@ export interface Enterprise<Transaction = unknown> extends EnterpriseConfigReade
   rent(rentRequest: RentRequest): Promise<Transaction>;
 
   getStakingReward(stakeTokenId: AssetId): Promise<BigNumber>;
+
+  getEnterpriseTokenMetadata(): Promise<FungibleTokenMetadata>;
 
   claimStakingReward(stakeTokenId: AssetId): Promise<Transaction>;
 

--- a/packages/enterprise/test/enterprise.test.ts
+++ b/packages/enterprise/test/enterprise.test.ts
@@ -2,6 +2,7 @@ import { AccountId, AssetId, AssetType, ChainId } from 'caip';
 import { BigNumber } from '@ethersproject/bignumber';
 import {
   EnterpriseInfo as OnChainEnterpriseInfo,
+  FungibleTokenMetadata,
   RentalAgreement as OnChainRentalAgreement,
 } from '@iqprotocol/abstract-blockchain';
 import { blockchainEnterpriseMock, blockchainProviderMock, blockchainServiceMock } from './support/mocks';
@@ -145,6 +146,23 @@ describe('Enterprise', () => {
     );
     expect(getStakingReward).toHaveBeenCalledWith(stakeTokenId);
     expect(reward).toEqual(expectedReward);
+  });
+
+  it('retrieves enterprise token metadata', async () => {
+    const expectedTokenMetadata: FungibleTokenMetadata = {
+      address: '',
+      decimals: 18,
+      name: 'EnterpriseToken',
+      symbol: 'ENT',
+    };
+    const getStakingReward = jest
+      .spyOn(blockchainEnterpriseMock, 'getEnterpriseTokenMetadata')
+      .mockResolvedValueOnce(expectedTokenMetadata);
+
+    const tokenMetadata = await enterprise.getEnterpriseTokenMetadata();
+
+    expect(getStakingReward).toHaveBeenCalledTimes(1);
+    expect(tokenMetadata).toEqual(expectedTokenMetadata);
   });
 
   it('allows to claim staking reward', async () => {


### PR DESCRIPTION
Proxy a call to retrieve enterprise token metadata through `Enterprise` to `blockchainEnterprise`. 